### PR TITLE
generate svg on changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: generate animation
 
 on:
+#   push: # uncomment to test GH action svg generation without cron
+#     branches:
+#     - master
   schedule:
     - cron: "0 */6 * * *" # every 6 hours
 


### PR DESCRIPTION
it's easier to test svg generation after forking repo into your profile.

Also it would be nice to update docs with steps:
1. fork repo
2. allow actions in settings
3. change cron or uncomment on push
4. change link to output svg in `README.md`