### PR TITLE
Fix cron expression in github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: generate animation
 on:
   # run automatically every 6 hours
   schedule:
-    - cron: "0 */8 * * *" 
+    - cron: "0 */6 * * *" 
   
   # allows to manually run the job at any time
   workflow_dispatch:


### PR DESCRIPTION
The comment says 6 hours but the cron expression said 8